### PR TITLE
small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,8 @@ A class used to generate a nonuniform distribution of random numbers.
 ## Usage
 
 ```
-var ndr = require('ndrand');
-
-ndr.initialize([
-  {x:0,y:0},
-  {x:5,y:5},
-  {x:10,y:0},
-]);
-
+const NDRandom = require('ndrand');
+var ndr=new NDRandom([ {x:0,y:0},{x:0.5,y:1}, {x:1,y:0} ])
 console.log(ndr.random());
 ```
 

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports=NDRandom;
 
 
 //example:
-// const NDRandom=require('ndrandom')
+// const NDRandom=require('ndrand')
 // var x=new NDRandom([ {x:0,y:0},{x:0.5,y:1}, {x:1,y:0} ])
 // x.random();
 


### PR DESCRIPTION
made this example work:

var ndr=new NDRandom([[0,1],  [0.5,1], [0.501,0], [1.399,0], [1.4,1], [1.6,4], [1.8,1], [1.801,0], [2,0] ].map(([x,y])=>({x,y})))
ndr.random()

http://jsfiddle.net/zsqqzbqq/1/

I fixed same y numbers with etta,  maybe a better solution could be just to use rect.   (probably x numbers can be also fixed with etta too. but i did not do it)

zero region result discarded and randomized again.